### PR TITLE
Using new import path for go/html package

### DIFF
--- a/opengraph.go
+++ b/opengraph.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"strings"
 
-	"code.google.com/p/go.net/html"
+	"golang.org/x/net/html"
 )
 
 type MetaData struct {


### PR DESCRIPTION
code.google.com is being 'put down', so it's best to start moving away. Cheers
